### PR TITLE
Fix format of xAPI correctResponsesPattern

### DIFF
--- a/goals-page.js
+++ b/goals-page.js
@@ -362,7 +362,7 @@ H5P.GoalsPage = (function ($, EventDispatcher) {
     };
     definition.type = 'http://adlnet.gov/expapi/activities/cmi.interaction';
     definition.interactionType = 'fill-in';
-    definition.correctResponsesPattern = '';
+    definition.correctResponsesPattern = [];
     definition.extensions = {
       'https://h5p.org/x-api/h5p-machine-name': 'H5P.GoalsPage'
     };


### PR DESCRIPTION
According to the xAPI specification, the correctResponsesPattern field is supposed to be an Array of strings, while the goal page sets it to be a string. See https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#correct-responses-pattern

If merged in, the correctResponsesPattern property will hold an empty Array instead of an empty string. If the value is not relevant at all, the definition could be omitted completely, because the correctResponsesPattern property is optional.